### PR TITLE
fix problem when migrate code to swift 4

### DIFF
--- a/CurrencyTextField/CurrencyTextField.swift
+++ b/CurrencyTextField/CurrencyTextField.swift
@@ -49,7 +49,7 @@ import UIKit
         }
     }
     
-    func textDidChange(_ notification: Notification){
+    @objc func textDidChange(_ notification: Notification){
         
         //Get the original position of the cursor
         let cursorOffset = getOriginalCursorPosition();

--- a/CurrencyTextFieldDemo/CurrencyTextFieldDemo.xcodeproj/project.pbxproj
+++ b/CurrencyTextFieldDemo/CurrencyTextFieldDemo.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Richa.CurrencyTextFieldDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -435,7 +435,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = Richa.CurrencyTextFieldDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I had a crash when use the library in swift 4, so, only add @objc in method textDidChange.